### PR TITLE
Remove SKY_Q flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function SkyQAccessory(log, config, api) {
 	this.config = config;
 	this.name = config.name || 'Sky Q';
 
-	var remoteControl = new SkyRemote(config.ipAddress, SkyRemote.SKY_Q);
+	var remoteControl = new SkyRemote(config.ipAddress);
 	this.skyQ = remoteControl;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var SkyRemote = require('sky-remote');
+var SkyQCheck = require('sky-q');
 var Accessory, Service, Characteristic;
 
 module.exports = function(homebridge) {
@@ -18,7 +19,9 @@ function SkyQAccessory(log, config, api) {
 	this.name = config.name || 'Sky Q';
 
 	var remoteControl = new SkyRemote(config.ipAddress);
+	var boxCheck = new SkyQCheck({ip:config.ipAddress})
 	this.skyQ = remoteControl;
+	this.box = boxCheck;
 }
 
 
@@ -49,11 +52,29 @@ SkyQAccessory.prototype = {
 		callback();
 	},
 
+	getState: function(callback) {
+		this.box.getPowerState().then(isOn=>{
+  		if (isOn) {
+		    this.log(this.name + " is on :-)")
+		  } else {
+		    this.log(this.name + " is in standby :-(")
+		  }
+		  callback(null, isOn);
+		}).catch(err=>{
+		  this.log("Unable to determine power state")
+		  this.log("Perhaps looking at this error will help you figure out why" + err)
+		  callback(err || new Error('Error getting state of ' + this.name));
+		})
+	},
+
 	getServices: function() {
 
 		var switchService = new Service.Switch(this.name);
+		
 
-		switchService.getCharacteristic(Characteristic.On).on('set', this.setPowerState.bind(this));
+		var characteristic = switchService.getCharacteristic(Characteristic.On).on('set', this.setPowerState.bind(this));
+
+		characteristic.on('get', this.getState.bind(this));
 
 		return [switchService];
 	}


### PR DESCRIPTION
No longer needed since v0.60 of Sky Q firmware - Sky reverted to the 'old' port also used on HD boxes